### PR TITLE
There is no data to read when the process being debugged exits

### DIFF
--- a/new/db/archos/linux-x64/dbg_bps
+++ b/new/db/archos/linux-x64/dbg_bps
@@ -176,5 +176,5 @@ e scr.null=false
 p8 4
 EXPECT=<<RUN
 Hello world!
-31ed5e89
+ffffffff
 RUN


### PR DESCRIPTION
I think this test was wrong, as once the process exits (after you do the last `dc`), it is not possible to read data anymore, so it seems right that fffffff is returned, instead of the old value there.

What do you think?