### PR TITLE
Revert "sym is not fcn" test to original flag

### DIFF
--- a/new/db/anal/x86_64
+++ b/new/db/anal/x86_64
@@ -642,13 +642,10 @@ RUN
 
 NAME=sym is not fcn
 FILE=../bins/mach0/mach0-i386
-EXPECT=<<EOF
-0x00001f50
-0x00001f00
-EOF
+EXPECT=''
 CMDS=<<EOF
 aa > /dev/null
-afl~foo,bar[0]
+afl~sym.__mh_execute_header[0]
 EOF
 RUN
 


### PR DESCRIPTION
As per https://github.com/radareorg/radare2-regressions/commit/238af86f37eb86a5ff43cbf93a0fae4c5dc4fdc4#diff-f65331988bc948a5d883839f352ba3cfR135-R143. Apparently, `__mh_execute_header` is the [address of the mach header](https://opensource.apple.com/source/cctools/cctools-921/include/mach-o/ldsyms.h.auto.html).