### PR TITLE
Revert "There is no data to read when the process being debugged exits"

### DIFF
--- a/new/db/archos/linux-x64/dbg_bps
+++ b/new/db/archos/linux-x64/dbg_bps
@@ -176,5 +176,5 @@ e scr.null=false
 p8 4
 EXPECT=<<RUN
 Hello world!
-ffffffff
+31ed5e89
 RUN


### PR DESCRIPTION
Reverts radareorg/radare2-regressions#1991