### PR TITLE
Use ONE_STREAM=1 instead and assume it sets scr.onestream

### DIFF
--- a/new/db/cmd/cmd_pd
+++ b/new/db/cmd/cmd_pd
@@ -1025,8 +1025,7 @@ EOF
 RUN
 
 NAME=bin.str.enc alias and error handling
-ONE_STREAM=true
-ARGS=-e scr.onestream=true
+ONE_STREAM=1
 FILE=../bins/elf/strenc
 CMDS=<<EOF
 e asm.filter=false

--- a/new/db/cmd/cmd_pf2
+++ b/new/db/cmd/cmd_pf2
@@ -438,7 +438,7 @@ RUN
 
 NAME=pf?
 FILE=-
-ONE_STREAM=true
+ONE_STREAM=1
 CMDS=<<EXPECT
 pfo elf32
 pf?elf_header

--- a/new/db/cmd/feat_foreach
+++ b/new/db/cmd/feat_foreach
@@ -49,7 +49,7 @@ RUN
 
 NAME=@@= `prz` fix
 FILE=-
-ONE_STREAM=true
+ONE_STREAM=1
 CMDS=<<EXPECT
 wz 1 2 3 4
 pd 1 @@= `prz`

--- a/new/db/tools/r2
+++ b/new/db/tools/r2
@@ -87,3 +87,10 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=ONE_STREAM sets scr.onestream
+FILE=-
+ONE_STREAM=1
+CMDS=e scr.onestream
+EXPECT=true
+RUN

--- a/new/package.json
+++ b/new/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "radare2 regressions testsuite",
   "dependencies": {
-    "node-r2r": "^0.2.5"
+    "node-r2r": "^0.2.6"
   },
   "author": "pancake <pancake@nopcode.org>",
   "license": "MIT"


### PR DESCRIPTION
Requires radare/node-r2r#11 and node-r2r 0.2.6 or higher.